### PR TITLE
fix: invalid characters when creating holograms

### DIFF
--- a/plugin/src/main/java/me/block2block/hubparkour/entities/LeaderboardHologram.java
+++ b/plugin/src/main/java/me/block2block/hubparkour/entities/LeaderboardHologram.java
@@ -50,9 +50,9 @@ public class LeaderboardHologram implements ILeaderboardHologram {
             HubParkour.getInstance().getLogger().info("The location of one of your leaderboard holograms for parkour " + parkour.getName() + " no longer exists. Please delete leaderboard hologram " + this.id + ".");
             return;
         }
-        hologram = DHAPI.getHologram("hp:leaderboard." + ((parkour == null)?"global":parkour.getId()) + "." + id);
+        hologram = DHAPI.getHologram("hp_leaderboard_" + ((parkour == null)?"global":parkour.getId()) + "_" + id);
         if (hologram == null) {
-            hologram = DHAPI.createHologram("hp:leaderboard." + ((parkour == null)?"global":parkour.getId()) + "." + id, location);
+            hologram = DHAPI.createHologram("hp_leaderboard_" + ((parkour == null)?"global":parkour.getId()) + "_" + id, location);
         } else {
             DHAPI.moveHologram(hologram, location);
         }

--- a/plugin/src/main/java/me/block2block/hubparkour/entities/Parkour.java
+++ b/plugin/src/main/java/me/block2block/hubparkour/entities/Parkour.java
@@ -168,9 +168,9 @@ public class Parkour implements IParkour {
             if (l.getWorld() == null) {
                 continue;
             }
-            Hologram hologram = DHAPI.getHologram("hp:" + id + "." + p.getType() + ((p instanceof Checkpoint)?"." + ((Checkpoint) p).getCheckpointNo():""));
+            Hologram hologram = DHAPI.getHologram("hp_" + id + "_" + p.getType() + ((p instanceof Checkpoint)?"_" + ((Checkpoint) p).getCheckpointNo():""));
             if (hologram == null) {
-                hologram = DHAPI.createHologram("hp:" + id + "." + p.getType() + ((p instanceof Checkpoint)?"." + ((Checkpoint) p).getCheckpointNo():""), l);
+                hologram = DHAPI.createHologram("hp_" + id + "_" + p.getType() + ((p instanceof Checkpoint)?"_" + ((Checkpoint) p).getCheckpointNo():""), l);
             } else {
                 DHAPI.moveHologram(hologram, l);
             }


### PR DESCRIPTION
This PR fix invalid characters error when creating holograms.

Starting on DecentHolograms 2.8.1, hologram name can only contain alphanumeric characters, underscores and dashes.