### PR TITLE
add drop listener

### DIFF
--- a/plugin/src/main/java/me/block2block/hubparkour/listeners/DropListener.java
+++ b/plugin/src/main/java/me/block2block/hubparkour/listeners/DropListener.java
@@ -1,5 +1,6 @@
 package me.block2block.hubparkour.listeners;
 
+import me.block2block.hubparkour.HubParkour;
 import me.block2block.hubparkour.api.HubParkourAPI;
 import me.block2block.hubparkour.api.items.ParkourItem;
 import me.block2block.hubparkour.managers.CacheManager;
@@ -40,18 +41,7 @@ public class DropListener implements Listener {
         if (e.getWhoClicked() instanceof Player) {
             Player player = (Player) e.getWhoClicked();
             if (CacheManager.isParkour(player)) {
-                for (ParkourItem item : HubParkourAPI.getPlayer(player).getParkourItems()) {
-                    if (item != null) {
-                        if (item.getItem() != null) {
-                            if (e.getCurrentItem() != null) {
-                                if (item.getItem().equals(e.getCurrentItem())) {
-                                    e.setCancelled(true);
-                                    return;
-                                }
-                            }
-                        }
-                    }
-                }
+                e.setCancelled(true);
             }
 
         }


### PR DESCRIPTION
Modified drop listener that prevents item dropping and interacting with containers

**Related Issues:**
When in a parkour, players were able to open containers and put game items (leave/checkpoint...) in those containers by hovering on any empty slot in the container and clicking SHIFT+(number), where "number" corresponds to a hotbar slot where the item is.

**Summary of Changes:**
To combat this, we made a patch that cancels all drop events when a player is active in parkour, which fixed the issue.

**Tests Performed:**
The plugin was tested for the issue described above. I can confirm that the issue is no longer present.

**I confirm that I've done the following:**
 - [X] Ensured all changes follow the [Contribution Guidelines](CONTRIBUTING.md).
 - [X] Fully tested all changes locally.
 - [ ] Updated the configuration file with any relevant changes.