### PR TITLE
Fix checkpoint timer & bubble column teleportation

### DIFF
--- a/plugin/src/main/java/me/block2block/hubparkour/entities/HubParkourPlayer.java
+++ b/plugin/src/main/java/me/block2block/hubparkour/entities/HubParkourPlayer.java
@@ -139,6 +139,7 @@ public class HubParkourPlayer implements IHubParkourPlayer {
 
     public void checkpoint(Checkpoint checkpoint) {
         if (lastReached == checkpoint.getCheckpointNo()) {
+            setCurrentSplit();
             return;
         }
         if (!checkpoints.contains(checkpoint)) {
@@ -249,8 +250,8 @@ public class HubParkourPlayer implements IHubParkourPlayer {
                     HubParkour.getInstance().getDbManager().reachedCheckpoint(player, parkour, checkpoint);
                 }
             }.runTaskAsynchronously(HubParkour.getInstance());
-
         }
+        setCurrentSplit();
     }
 
     public void end(ParkourPlayerFailEvent.FailCause cause) {
@@ -542,7 +543,7 @@ public class HubParkourPlayer implements IHubParkourPlayer {
         return player;
     }
 
-    public void setCurrentSplit(){
+    private void setCurrentSplit(){
         currentSplit = System.currentTimeMillis();
     }
 

--- a/plugin/src/main/java/me/block2block/hubparkour/entities/HubParkourPlayer.java
+++ b/plugin/src/main/java/me/block2block/hubparkour/entities/HubParkourPlayer.java
@@ -139,7 +139,6 @@ public class HubParkourPlayer implements IHubParkourPlayer {
 
     public void checkpoint(Checkpoint checkpoint) {
         if (lastReached == checkpoint.getCheckpointNo()) {
-            currentSplit = System.currentTimeMillis();
             return;
         }
         if (!checkpoints.contains(checkpoint)) {
@@ -541,6 +540,10 @@ public class HubParkourPlayer implements IHubParkourPlayer {
 
     public Player getPlayer() {
         return player;
+    }
+
+    public void setCurrentSplit(){
+        currentSplit = System.currentTimeMillis();
     }
 
     public void restart() {

--- a/plugin/src/main/java/me/block2block/hubparkour/listeners/PressurePlateListener.java
+++ b/plugin/src/main/java/me/block2block/hubparkour/listeners/PressurePlateListener.java
@@ -99,7 +99,7 @@ public class PressurePlateListener implements Listener {
                 boolean tplava = ConfigUtil.getBoolean("Settings.Teleport.On-Lava", true);
                 ParkourPlayerTeleportEvent.TeleportReason reason =
                         ParkourPlayerTeleportEvent.TeleportReason.UNKNOWN;
-                if (e.getTo().getBlock().getType() == Material.WATER) {
+                if (e.getTo().getBlock().getType() == Material.WATER || e.getTo().getBlock().getType() == Material.BUBBLE_COLUMN) {
                     reason = ParkourPlayerTeleportEvent.TeleportReason.WATER;
                     if (!tpwater) {
                         return;
@@ -364,6 +364,7 @@ public class PressurePlateListener implements Listener {
                             }
 
                             player.checkpoint(checkpoint);
+                            player.setCurrentSplit();
                             return;
                         } else {
                             //Do nothing, is doing a different parkour.

--- a/plugin/src/main/java/me/block2block/hubparkour/listeners/PressurePlateListener.java
+++ b/plugin/src/main/java/me/block2block/hubparkour/listeners/PressurePlateListener.java
@@ -364,7 +364,6 @@ public class PressurePlateListener implements Listener {
                             }
 
                             player.checkpoint(checkpoint);
-                            player.setCurrentSplit();
                             return;
                         } else {
                             //Do nothing, is doing a different parkour.


### PR DESCRIPTION
**Related Issues:**
N/A

**Summary of Changes:**
 - Fixed checkpoint timer only resetting when teleported back to the checkpoint, not when the player first reached it.
 - Fixed when water teleportation is disabled, player would still get teleported back when touching bubble columns

**Tests Performed:**
Both fixes are tested on paper 1.20.1 server.

**I confirm that I've done the following:**
 - [x] Ensured all changes follow the [Contribution Guidelines](CONTRIBUTING.md).
 - [x] Fully tested all changes locally.
 - [x] Updated the configuration file with any relevant changes.