### PR TITLE
feat: block inventory clicks feature

### DIFF
--- a/plugin/src/main/java/me/block2block/hubparkour/listeners/DropListener.java
+++ b/plugin/src/main/java/me/block2block/hubparkour/listeners/DropListener.java
@@ -40,6 +40,11 @@ public class DropListener implements Listener {
         if (e.getWhoClicked() instanceof Player) {
             Player player = (Player) e.getWhoClicked();
             if (CacheManager.isParkour(player)) {
+                if (ConfigUtil.getBoolean("Settings.Exploit-Prevention.Block-Inventory-Clicks", false)) {
+                    e.setCancelled(true);
+                    return;
+                }
+
                 for (ParkourItem item : HubParkourAPI.getPlayer(player).getParkourItems()) {
                     if (item != null) {
                         if (item.getItem() != null) {

--- a/plugin/src/main/resources/config1_13.yml
+++ b/plugin/src/main/resources/config1_13.yml
@@ -474,6 +474,9 @@ Settings:
     #It is recommended to keep this disabled to prevent farming of a single checkpoint. This setting overrides repeat rewards
     #Note that this does not effect checkpoints reached in a single run, once a checkpoint reward is given in a run, it cannot be given again for the same checkpoint.
     Checkpoint-Rewards-Everytime: false
+    #Whether to prevent all inventory clicks while in parkour.
+    #This blocks clicking any items in the inventory, not just parkour items.
+    Block-Inventory-Clicks: false
     #Whether a player should be failed for doing these specific things.
     Fail:
       On-Teleport: true

--- a/plugin/src/main/resources/config1_8.yml
+++ b/plugin/src/main/resources/config1_8.yml
@@ -474,6 +474,9 @@ Settings:
     #It is recommended to keep this disabled to prevent farming of a single checkpoint. This setting overrides repeat rewards
     #Note that this does not effect checkpoints reached in a single run, once a checkpoint reward is given in a run, it cannot be given again for the same checkpoint.
     Checkpoint-Rewards-Everytime: false
+    #Whether to prevent all inventory clicks while in parkour.
+    #This blocks clicking any items in the inventory, not just parkour items.
+    Block-Inventory-Clicks: false
     #Whether a player should be failed for doing these specific things.
     Fail:
       On-Teleport: true


### PR DESCRIPTION
Modified drop listener that prevents item dropping and interacting with containers

**Related Issues:**
When in a parkour, players were able to open containers and put game items (leave/checkpoint...) in those containers by hovering on any empty slot in the container and clicking SHIFT+(number), where "number" corresponds to a hotbar slot where the item is.

**Summary of Changes:**
To combat this, we made a patch that cancels all drop events when a player is active in parkour, which fixed the issue.

**Tests Performed:**
Any relevant tests that were performed locally

**I confirm that I've done the following:**
 - [x] Ensured all changes follow the [Contribution Guidelines](CONTRIBUTING.md).
 - [x] Fully tested all changes locally.
 - [x] Updated the configuration file with any relevant changes.